### PR TITLE
fix(mp4grep-convert): Add missing doublequotes

### DIFF
--- a/mp4grep-convert
+++ b/mp4grep-convert
@@ -23,25 +23,25 @@ function extract_audio_from_dir
 {
     for file in "$1"/*
     do
-	is_audio_test=$(is_audio_file $file)
-	if [ $is_audio_test -eq 1 ]
+	is_audio_test=$(is_audio_file "$file")
+	if [ "$is_audio_test" -eq 1 ]
 	then
-	    audio_file_lst+=($file)
+	    audio_file_lst+=("$file")
 	fi
     done
 }
 
 audio_file_lst=()
-for inp in $*
+for inp in "$@"
 do
-    is_audio_test=$(is_audio_file $inp)
-    if [ $is_audio_test -eq 1 ] 
+    is_audio_test=$(is_audio_file "$inp")
+    if [ "$is_audio_test" -eq 1 ] 
     then
-	audio_file_lst+=($inp)
+	audio_file_lst+=("$inp")
     elif [ -d "${inp}" ]
     then
 	echo "${inp} is a directory, extracting audio files."
-	extract_audio_from_dir $inp
+	extract_audio_from_dir "$inp"
     else
 	echo "${inp} is not an audio file or directory. Doing nothing."
     fi
@@ -50,14 +50,14 @@ done
 
 echo "Files that will be converted:"
 echo "-----------------------------"
-for audio in ${audio_file_lst[@]}
+for audio in "${audio_file_lst[@]}"
 do
     echo "${audio} -> ${audio}.wav"
 done
 echo "-----------------------------"
 
 
-for audio in ${audio_file_lst[@]}
+for audio in "${audio_file_lst[@]}"
 do
     ffmpeg -hide_banner -loglevel error -i "$audio" -acodec pcm_s16le -ac 1 -ar 16000 "${audio}.wav"
 done


### PR DESCRIPTION
Add missing double quotes to avoid various parameter splitting issues
(Basically just following "shellcheck" output and fix all the issues)
